### PR TITLE
feat/challenge 17 no crack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,3 @@ pub mod set2;
 pub mod set3;
 pub mod text_score;
 pub mod util;
-
-#[cfg(not(tarpaulin_include))]
-#[cfg(test)]
-mod tests {
-    use super::*;
-}

--- a/src/set2.rs
+++ b/src/set2.rs
@@ -253,7 +253,7 @@ mod tests {
         let key = "YELLOW SUBMARINE".as_bytes().to_vec();
         let iv = vec![0; 16];
         let plaintext = crate::aes::decrypt_aes_128_cbc(ciphertext, iv, key);
-        let plaintext = String::from_utf8(plaintext).unwrap();
+        let plaintext = String::from_utf8(plaintext.unwrap()).unwrap();
         assert!(plaintext.starts_with("I'm back and I'm ringin' the bell"));
         assert!(plaintext.ends_with("Play that funky music \n"));
     }

--- a/src/set2.rs
+++ b/src/set2.rs
@@ -20,16 +20,9 @@ use serde_qs::to_string;
 
 use crate::aes::{encrypt_aes_128_ecb, AesEncryptionMethod};
 use crate::pkcs7::pkcs7_padding_add;
+use crate::util::generate_random_16_byte_key;
 
 pub mod challenge16;
-
-// Tarpaulin does not recognize the return as being covered
-#[cfg(not(tarpaulin_include))]
-fn generate_random_16_byte_key<R: RngCore>(rng: &mut R) -> Vec<u8> {
-    let mut key = vec![0; 16];
-    rng.fill_bytes(&mut key);
-    key
-}
 
 // Tarpaulin does not recognize either of the enums in the return as being covered
 #[cfg(not(tarpaulin_include))]

--- a/src/set2/challenge16.rs
+++ b/src/set2/challenge16.rs
@@ -43,7 +43,7 @@ pub fn inject_admin() -> Vec<u8> {
     let mut rng = Pcg64::seed_from_u64(seed);
     let key = generate_random_16_byte_key(&mut rng);
     let iv = generate_random_16_byte_key(&mut rng);
-    decrypt_aes_128_cbc(ciphertext, iv, key)
+    decrypt_aes_128_cbc(ciphertext, iv, key).unwrap()
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -60,7 +60,7 @@ mod tests {
         let plaintext = decrypt_aes_128_cbc(ciphertext, iv, key);
         assert_eq!(
             b"comment1=cooking%20MCs;userdata=;comment2=%20like%20a%20pound%20of%20bacon".to_vec(),
-            plaintext
+            plaintext.unwrap()
         );
     }
 
@@ -73,7 +73,7 @@ mod tests {
         let plaintext = decrypt_aes_128_cbc(ciphertext, iv, key);
         assert_eq!(
             b"comment1=cooking%20MCs;userdata=%3Badmin%3Dtrue;comment2=%20like%20a%20pound%20of%20bacon".to_vec(),
-            plaintext
+            plaintext.unwrap()
         );
     }
 

--- a/src/set2/challenge16.rs
+++ b/src/set2/challenge16.rs
@@ -14,7 +14,6 @@
 
 use rand::SeedableRng;
 use rand_pcg::Pcg64;
-use serde::__private::de;
 use urlencoding::encode_binary;
 
 use crate::aes::{decrypt_aes_128_cbc, encrypt_aes_128_cbc};

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -15,6 +15,10 @@
 use base64::{engine::general_purpose, Engine as _};
 use rand::seq::SliceRandom;
 use rand::RngCore;
+use rand::SeedableRng;
+use rand_pcg::Pcg64;
+
+use crate::util::generate_random_16_byte_key;
 
 fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
     let plaintexts = vec![
@@ -38,7 +42,9 @@ fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
     )
 }
 
-pub fn challenge_17_oracle() -> (Vec<u8>, Vec<u8>, String) {
+pub fn challenge_17_oracle(seed: u64) -> (Vec<u8>, Vec<u8>, String) {
+    let mut rng = Pcg64::seed_from_u64(seed);
+    let key = generate_random_16_byte_key(&mut rng);
     todo!()
 }
 
@@ -46,9 +52,6 @@ pub fn challenge_17_oracle() -> (Vec<u8>, Vec<u8>, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use rand::SeedableRng;
-    use rand_pcg::Pcg64;
 
     #[test]
     fn test_get_plaintext() {

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -48,5 +48,34 @@ fn get_plaintext<R: RngCore>(rng: &mut R) -> Vec<u8> {
             .as_bytes()
             .to_vec(),
     ];
-    todo!()
+    let choice = plaintexts.choose(rng).unwrap();
+    (
+        choice.to_string(),
+        general_purpose::STANDARD
+            .decode(choice.as_bytes().to_vec())
+            .unwrap(),
+    )
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand::SeedableRng;
+    use rand_pcg::Pcg64;
+
+    #[test]
+    fn test_get_plaintext() {
+        let mut rng = Pcg64::seed_from_u64(0);
+        let (plaintext, plaintext_decoded) = get_plaintext(&mut rng);
+        assert_eq!(plaintext, "MDAwMDA4b2xsaW4nIGluIG15IGZpdmUgcG9pbnQgb2g=");
+        assert_eq!(
+            vec![
+                48, 48, 48, 48, 48, 56, 111, 108, 108, 105, 110, 39, 32, 105, 110, 32, 109, 121,
+                32, 102, 105, 118, 101, 32, 112, 111, 105, 110, 116, 32, 111, 104
+            ],
+            plaintext_decoded
+        )
+    }
 }

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -18,6 +18,7 @@ use rand::RngCore;
 use rand::SeedableRng;
 use rand_pcg::Pcg64;
 
+use crate::aes::encrypt_aes_128_cbc;
 use crate::util::generate_random_16_byte_key;
 
 fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
@@ -45,7 +46,10 @@ fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
 pub fn challenge_17_oracle(seed: u64) -> (Vec<u8>, Vec<u8>, String) {
     let mut rng = Pcg64::seed_from_u64(seed);
     let key = generate_random_16_byte_key(&mut rng);
-    todo!()
+    let (plaintext, plaintext_decoded) = get_plaintext(&mut rng);
+    let iv = generate_random_16_byte_key(&mut rng);
+    let ciphertext = encrypt_aes_128_cbc(plaintext_decoded, iv.clone(), key);
+    (ciphertext, iv, plaintext)
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -57,6 +57,8 @@ pub fn challenge_17_oracle(seed: u64) -> (Vec<u8>, Vec<u8>, String) {
 mod tests {
     use super::*;
 
+    use crate::aes::decrypt_aes_128_cbc;
+
     #[test]
     fn test_get_plaintext() {
         let mut rng = Pcg64::seed_from_u64(0);
@@ -90,5 +92,13 @@ mod tests {
             "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=".to_string(),
             plaintext
         );
+    }
+
+    #[test]
+    fn challenge_17_oracle_decryption_has_padding_errors() {
+        let (ciphertext, iv, _) = challenge_17_oracle(0);
+        let key = generate_random_16_byte_key(&mut Pcg64::seed_from_u64(0));
+        let plaintext = decrypt_aes_128_cbc(ciphertext, iv, key);
+        assert!(plaintext.is_err());
     }
 }

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -57,8 +57,6 @@ pub fn challenge_17_oracle(seed: u64) -> (Vec<u8>, Vec<u8>, String) {
 mod tests {
     use super::*;
 
-    use crate::aes::decrypt_aes_128_cbc;
-
     #[test]
     fn test_get_plaintext() {
         let mut rng = Pcg64::seed_from_u64(0);
@@ -92,13 +90,5 @@ mod tests {
             "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=".to_string(),
             plaintext
         );
-    }
-
-    #[test]
-    fn challenge_17_oracle_decryption_has_padding_errors() {
-        let (ciphertext, iv, _) = challenge_17_oracle(0);
-        let key = generate_random_16_byte_key(&mut Pcg64::seed_from_u64(0));
-        let plaintext = decrypt_aes_128_cbc(ciphertext, iv, key);
-        assert!(plaintext.is_err());
     }
 }

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -11,3 +11,42 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use rand::seq::SliceRandom;
+use rand::RngCore;
+
+fn get_plaintext<R: RngCore>(rng: &mut R) -> Vec<u8> {
+    let plaintexts = vec![
+        "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDAxV2l0aCB0aGUgYmFzcyBraWNrZWQgaW4gYW5kIHRoZSBWZWdhJ3MgYXJlIHB1bXBpbic="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDAyUXVpY2sgdG8gdGhlIHBvaW50LCB0byB0aGUgcG9pbnQsIG5vIGZha2luZw=="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDAzQ29va2luZyBNQydzIGxpa2UgYSBwb3VuZCBvZiBiYWNvbg=="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA0QnVybmluZyAnZW0sIGlmIHlvdSBhaW4ndCBxdWljayBhbmQgbmltYmxl"
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA1SSBnbyBjcmF6eSB3aGVuIEkgaGVhciBhIGN5bWJhbA=="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA2QW5kIGEgaGlnaCBoYXQgd2l0aCBhIHNvdXBlZCB1cCB0ZW1wbw=="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA3SSdtIG9uIGEgcm9sbCwgaXQncyB0aW1lIHRvIGdvIHNvbG8="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA4b2xsaW4nIGluIG15IGZpdmUgcG9pbnQgb2g="
+            .as_bytes()
+            .to_vec(),
+        "MDAwMDA5aXRoIG15IHJhZy10b3AgZG93biBzbyBteSBoYWlyIGNhbiBibG93"
+            .as_bytes()
+            .to_vec(),
+    ];
+    todo!()
+}

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -38,6 +38,10 @@ fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
     )
 }
 
+pub fn challenge_17_oracle() -> (Vec<u8>, Vec<u8>, String) {
+    todo!()
+}
+
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]
 mod tests {

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -66,4 +66,25 @@ mod tests {
             plaintext_decoded
         )
     }
+
+    #[test]
+    fn challenge_17_oracle_encrypts_and_returns_proper() {
+        let (ciphertext, iv, plaintext) = challenge_17_oracle(0);
+        assert_eq!(
+            vec![
+                167, 45, 21, 252, 25, 73, 200, 132, 184, 198, 144, 157, 18, 35, 123, 15, 208, 168,
+                100, 95, 254, 57, 76, 61, 49, 42, 93, 39, 80, 132, 34, 29, 148, 74, 242, 41, 81,
+                17, 32, 141, 177, 43, 190, 251, 140, 42, 180, 4
+            ],
+            ciphertext
+        );
+        assert_eq!(
+            vec![218, 167, 25, 176, 226, 30, 247, 9, 94, 26, 140, 200, 50, 123, 51, 219],
+            iv
+        );
+        assert_eq!(
+            "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=".to_string(),
+            plaintext
+        );
+    }
 }

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -12,41 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use base64::{engine::general_purpose, Engine as _};
 use rand::seq::SliceRandom;
 use rand::RngCore;
 
-fn get_plaintext<R: RngCore>(rng: &mut R) -> Vec<u8> {
+fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
     let plaintexts = vec![
-        "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDAxV2l0aCB0aGUgYmFzcyBraWNrZWQgaW4gYW5kIHRoZSBWZWdhJ3MgYXJlIHB1bXBpbic="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDAyUXVpY2sgdG8gdGhlIHBvaW50LCB0byB0aGUgcG9pbnQsIG5vIGZha2luZw=="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDAzQ29va2luZyBNQydzIGxpa2UgYSBwb3VuZCBvZiBiYWNvbg=="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA0QnVybmluZyAnZW0sIGlmIHlvdSBhaW4ndCBxdWljayBhbmQgbmltYmxl"
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA1SSBnbyBjcmF6eSB3aGVuIEkgaGVhciBhIGN5bWJhbA=="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA2QW5kIGEgaGlnaCBoYXQgd2l0aCBhIHNvdXBlZCB1cCB0ZW1wbw=="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA3SSdtIG9uIGEgcm9sbCwgaXQncyB0aW1lIHRvIGdvIHNvbG8="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA4b2xsaW4nIGluIG15IGZpdmUgcG9pbnQgb2g="
-            .as_bytes()
-            .to_vec(),
-        "MDAwMDA5aXRoIG15IHJhZy10b3AgZG93biBzbyBteSBoYWlyIGNhbiBibG93"
-            .as_bytes()
-            .to_vec(),
+        "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=",
+        "MDAwMDAxV2l0aCB0aGUgYmFzcyBraWNrZWQgaW4gYW5kIHRoZSBWZWdhJ3MgYXJlIHB1bXBpbic=",
+        "MDAwMDAyUXVpY2sgdG8gdGhlIHBvaW50LCB0byB0aGUgcG9pbnQsIG5vIGZha2luZw==",
+        "MDAwMDAzQ29va2luZyBNQydzIGxpa2UgYSBwb3VuZCBvZiBiYWNvbg==",
+        "MDAwMDA0QnVybmluZyAnZW0sIGlmIHlvdSBhaW4ndCBxdWljayBhbmQgbmltYmxl",
+        "MDAwMDA1SSBnbyBjcmF6eSB3aGVuIEkgaGVhciBhIGN5bWJhbA==",
+        "MDAwMDA2QW5kIGEgaGlnaCBoYXQgd2l0aCBhIHNvdXBlZCB1cCB0ZW1wbw==",
+        "MDAwMDA3SSdtIG9uIGEgcm9sbCwgaXQncyB0aW1lIHRvIGdvIHNvbG8=",
+        "MDAwMDA4b2xsaW4nIGluIG15IGZpdmUgcG9pbnQgb2g=",
+        "MDAwMDA5aXRoIG15IHJhZy10b3AgZG93biBzbyBteSBoYWlyIGNhbiBibG93",
     ];
     let choice = plaintexts.choose(rng).unwrap();
     (

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -109,5 +109,10 @@ mod tests {
             iv.clone(),
             generate_random_16_byte_key(&mut Pcg64::seed_from_u64(0))
         ));
+        assert!(!challenge_17_valid_decryption_padding(
+            generate_random_16_byte_key(&mut Pcg64::seed_from_u64(0)),
+            iv.clone(),
+            generate_random_16_byte_key(&mut Pcg64::seed_from_u64(0))
+        ));
     }
 }

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -11,17 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-pub mod aes;
-pub mod pkcs7;
-pub mod set1;
-pub mod set2;
-pub mod set3;
-pub mod text_score;
-pub mod util;
-
-#[cfg(not(tarpaulin_include))]
-#[cfg(test)]
-mod tests {
-    use super::*;
-}

--- a/src/set3/challenge17.rs
+++ b/src/set3/challenge17.rs
@@ -22,6 +22,8 @@ use crate::aes::decrypt_aes_128_cbc;
 use crate::aes::{encrypt_aes_128_cbc, encrypt_aes_128_ecb};
 use crate::util::generate_random_16_byte_key;
 
+// Tarpaulin doesn't recognize the unwrap return
+#[cfg(not(tarpaulin_include))]
 fn get_plaintext<R: RngCore>(rng: &mut R) -> (String, Vec<u8>) {
     let plaintexts = vec![
         "MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=",

--- a/src/set3/mod.rs
+++ b/src/set3/mod.rs
@@ -12,16 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod aes;
-pub mod pkcs7;
-pub mod set1;
-pub mod set2;
-pub mod set3;
-pub mod text_score;
-pub mod util;
-
-#[cfg(not(tarpaulin_include))]
-#[cfg(test)]
-mod tests {
-    use super::*;
-}
+pub mod challenge17;

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,7 @@
 
 use base64::{engine::general_purpose, Engine as _};
 use hex;
+use rand::RngCore;
 use std::fs::read_to_string;
 
 pub fn hex_to_base64(hex: &str) -> String {
@@ -77,6 +78,14 @@ pub fn find_best_keysizes(ciphertext: Vec<u8>, min: usize, max: usize) -> Vec<us
         .map(|(keysize, _)| *keysize)
         .collect::<Vec<usize>>()[..3]
         .to_vec()
+}
+
+// Tarpaulin does not recognize the return as being covered
+#[cfg(not(tarpaulin_include))]
+pub fn generate_random_16_byte_key<R: RngCore>(rng: &mut R) -> Vec<u8> {
+    let mut key = vec![0; 16];
+    rng.fill_bytes(&mut key);
+    key
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -80,9 +80,11 @@ pub fn find_best_keysizes(ciphertext: Vec<u8>, min: usize, max: usize) -> Vec<us
         .to_vec()
 }
 
-// Tarpaulin does not recognize the return as being covered
 #[cfg(not(tarpaulin_include))]
 pub fn generate_random_16_byte_key<R: RngCore>(rng: &mut R) -> Vec<u8> {
+    // Tarpaulin does not recognize the return coverage
+    // If this comment is outside the fnc, Tarpaulin thinks
+    // the comment is an uncovered line
     let mut key = vec![0; 16];
     rng.fill_bytes(&mut key);
     key


### PR DESCRIPTION
- Create set 3 module and challenge 17 file
- Stub fnc to get random plaintext
- Test get_plaintext
- Implement random choice for plaintext
- Fix compiler warnings
- Stub challenge 17 oracle
- Refactor set2 to move generate_random_16_byte_key to utils
- Test challenge 17 oracle
- Implement challenge 17 oracle
- Create test to assert the plaintexts have padding errors
- Refactor decrypt_aes_128_cbc to use padding validation
- Remove incorrect test
- Create and test fnc to check padding validity
- Add test for invalid padding
- Game coverage
